### PR TITLE
Tests, metacharacter output and noneOf (renamed to neither)

### DIFF
--- a/src/main/dsl/Escape.kt
+++ b/src/main/dsl/Escape.kt
@@ -1,14 +1,14 @@
 package dsl
 
-class Escape: Group() {
+class Escape(val type: EscapeType): Group() {
     override fun toString(): String {
-        TODO()
+        return type.code
     }
 }
 
 enum class EscapeType(val code: String) {
-    TAB("\t"),
-    BACKSLASH("\\"),
-    RETURN("\r"),
-    NEWLINE("\n")
+    TAB("\\t"),
+    BACKSLASH("\\\\"),
+    RETURN("\\r"),
+    NEWLINE("\\n")
 }

--- a/src/main/dsl/Groups.kt
+++ b/src/main/dsl/Groups.kt
@@ -12,7 +12,7 @@ class Range(private val range: CharRange, private val negated: Boolean) : Group(
         return if (negated) {
             "[^${range.first}-${range.last}]"
         } else {
-            "${range.first}-${range.last}"
+            "[${range.first}-${range.last}]"
         }
     }
 }

--- a/src/main/dsl/Regex.kt
+++ b/src/main/dsl/Regex.kt
@@ -6,6 +6,7 @@ import dsl.RepetitionType.*
 
 open class Regex {
     internal val groups: MutableList<Regex> = mutableListOf()
+    internal val tests: MutableList<TestCase> = mutableListOf()
     
     override fun toString(): String {
         return groups.joinToString(separator = "")
@@ -120,8 +121,29 @@ open class Regex {
         groups += regex
         return this
     }
+    
+    // TODO enforce grouping
+    fun matches(init: Match.() -> String): Regex {
+        val t = Match(Match("").init())
+        tests += t
+        return this
+    }
+    
+    fun no_match(init: NoMatch.() -> String): Regex {
+        val noMatch = NoMatch(NoMatch("").init())
+        tests += noMatch
+        return this
+    }
+    
+    fun runTests(exp : kotlin.text.Regex) {
+        for (test in tests) {
+            test.run(exp)
+        }
+    }
 }
 
 fun regex(init: Regex.() -> Regex): kotlin.text.Regex {
-    return Regex(Regex().init().toString())
+    val regex = Regex().init()
+    regex.runTests(Regex(regex.toString()))
+    return Regex(regex.toString())
 }

--- a/src/main/dsl/Regex.kt
+++ b/src/main/dsl/Regex.kt
@@ -19,7 +19,7 @@ open class Regex {
     }
     
     fun character(negated: Boolean = false, init: Selection.() -> Char): Regex {
-        val character = Character(Selection().init(), negated)
+        val character = Character(Selection(false).init(), negated)
         groups += character
         return this
     }
@@ -31,13 +31,13 @@ open class Regex {
     }
     
     fun range(negated: Boolean = false, init: Selection.() -> CharRange): Regex {
-        val range = Range(Selection().init(), negated)
+        val range = Range(Selection(false).init(), negated)
         groups += range
         return this
     }
     
     fun metacharacter(negated: Boolean = false, init: Selection.() -> MetacharacterType): Regex {
-        val metacharacter = Metacharacter(Selection().init(), negated)
+        val metacharacter = Metacharacter(Selection(false).init(), negated)
         groups += metacharacter
         return this
     }
@@ -95,7 +95,13 @@ open class Regex {
     }
     
     fun either(init: Selection.() -> Regex): Regex {
-        val selection = Selection().init()
+        val selection = Selection(false).init()
+        groups += selection
+        return this
+    }
+    
+    fun neither(init: Selection.() -> Regex): Regex {
+        val selection = Selection(true).init()
         groups += selection
         return this
     }

--- a/src/main/dsl/Regex.kt
+++ b/src/main/dsl/Regex.kt
@@ -42,6 +42,12 @@ open class Regex {
         return this
     }
     
+    fun escape(init: () -> EscapeType): Regex {
+        val e = Escape(init())
+        groups += e
+        return this
+    }
+    
     fun capture(init: CaptureGroup.() -> Regex): Regex {
         val captureGroup = CaptureGroup().init()
         groups += captureGroup
@@ -122,7 +128,7 @@ open class Regex {
         return this
     }
     
-    // TODO enforce grouping
+    // TODO enforce grouping (optional)
     fun matches(init: Match.() -> String): Regex {
         val t = Match(Match("").init())
         tests += t

--- a/src/main/dsl/Selection.kt
+++ b/src/main/dsl/Selection.kt
@@ -1,22 +1,37 @@
 package dsl
 
-class Selection : Group() {
+class Selection(val negated: Boolean) : Group() {
     
     override fun toString(): String {
-        var result = "("
+        var result = ""
+        if (negated) {
+            result += "[^"
     
-        for (g in groups) {
-            result += when (g) {
-                is Character -> g.toString()
-                // TODO
-                else -> g.toString()
+            for (g in groups) {
+                result += when (g) {
+                    is Character -> g.toString()
+                    else -> g.toString().replace("[", "").replace("]", "")
+                }
             }
-            result += "|"
-        }
-        result = result.dropLast(1)
-        result += ")"
+            result += "]"
     
-        return result
+            return result
+    
+        } else {
+            result += "("
+    
+            for (g in groups) {
+                result += when (g) {
+                    is Character -> g.toString()
+                    else -> g.toString()
+                }
+                result += "|"
+            }
+            result = result.dropLast(1)
+            result += ")"
+    
+            return result
+        }
         
         // var result = ""
         //

--- a/src/main/dsl/Selection.kt
+++ b/src/main/dsl/Selection.kt
@@ -13,6 +13,7 @@ class Selection : Group() {
             }
             result += "|"
         }
+        result = result.dropLast(1)
         result += ")"
     
         return result

--- a/src/main/dsl/Selection.kt
+++ b/src/main/dsl/Selection.kt
@@ -3,7 +3,7 @@ package dsl
 class Selection : Group() {
     
     override fun toString(): String {
-        var result = ""
+        var result = "("
     
         for (g in groups) {
             result += when (g) {
@@ -11,7 +11,9 @@ class Selection : Group() {
                 // TODO
                 else -> g.toString()
             }
+            result += "|"
         }
+        result += ")"
     
         return result
         

--- a/src/main/dsl/TestCase.kt
+++ b/src/main/dsl/TestCase.kt
@@ -1,0 +1,21 @@
+package dsl
+
+abstract class TestCase {
+    abstract fun run(exp : kotlin.text.Regex)
+}
+
+class Match(private val text: String) : TestCase() {
+    override fun run(exp : kotlin.text.Regex) {
+        if (!exp.matches(text)) {
+            throw AssertionError("Failed to match: $text")
+        }
+    }
+}
+
+class NoMatch(private val text: String) : TestCase() {
+    override fun run(exp : kotlin.text.Regex) {
+        if (exp.matches(text)) {
+            throw AssertionError("Unexpected match: $text")
+        }
+    }
+}

--- a/src/test/RegexTest.kt
+++ b/src/test/RegexTest.kt
@@ -104,14 +104,6 @@ internal class RegexTest {
             no_match { "0" }
         }
         
-        
-        println(regex {
-            either {
-                literal { "a" }
-                literal { "b" }
-                literal { "c" }
-            }
-        })
         regex {
             either {
                 literal { "a" }
@@ -213,8 +205,6 @@ internal class RegexTest {
     
     @Test
     fun testNegatedRange() {
-        print(regex {
-            range(negated = true) { 'a'..'z' }}.toString())
         regex {
             range(negated = true) { 'a'..'z' }
             
@@ -277,4 +267,57 @@ internal class RegexTest {
             no_match { "rrrrr" }
         }
     }
+    
+    @Test
+    fun testCharacter() {
+        regex {
+            character(negated = true) { 'x' }
+            
+            matches { "y" }
+            no_match { "x" }
+        }
+    }
+    
+    @Test
+    fun testEscape() {
+        regex {
+            either{
+                escape { EscapeType.BACKSLASH }
+                escape { EscapeType.NEWLINE }
+                escape { EscapeType.TAB }
+                escape { EscapeType.RETURN }
+            }
+            
+            matches { "\\" }
+            matches { "\n" }
+            matches { "\t" }
+            matches { "\r" }
+            no_match { " " }
+            no_match { "a" }
+        }
+    }
+    
+    // TODO
+//    @Test
+//    fun testAtomicGroup() {
+//        regex {
+//
+//        }
+//    }
+    
+    // TODO
+//    @Test
+//    fun testCaptureGroup() {
+//        regex {
+//
+//        }
+//    }
+    
+    // TODO
+//    @Test
+//    fun testLookaround() {
+//        regex {
+//
+//        }
+//    }
 }

--- a/src/test/RegexTest.kt
+++ b/src/test/RegexTest.kt
@@ -151,25 +151,31 @@ internal class RegexTest {
     
     @Test
     fun testNoneOf() {
-        // TODO allow this behavior
-//        assertEquals("[^a-z]", regex {
-//            range(negated = true) { 'a'..'z' }
-//        }.toString())
-//
-//        assertEquals("[^abc]", regex {
-//            noneOf {
-//                "abc"
-//            }
-//        }.toString())
-//
-//        assertEquals("[^D-Fabc]", regex {
-//            noneOf {
-//                range { 'D'..'F' }
-//                literal { "a" }
-//                literal { "b" }
-//                literal { "c" }
-//            }
-//        }.toString())
+        regex {
+            range(negated = true) { 'a'..'z' }
+            
+            matches { "2" }
+            matches { "G" }
+            no_match { "a" }
+            no_match { "j" }
+        }
+        
+        regex {
+            neither {
+                range { 'D'..'F' }
+                literal { "a" }
+                literal { "b" }
+                literal { "c" }
+            }
+            
+            matches { "A" }
+            matches { "z" }
+            no_match { "D" }
+            no_match { "E" }
+            no_match { "F" }
+            no_match { "b" }
+            no_match { "c" }
+        }
     }
     
     @Test

--- a/src/test/RegexTest.kt
+++ b/src/test/RegexTest.kt
@@ -1,0 +1,278 @@
+import dsl.*
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class RegexTest {
+    
+    @Test
+    fun testOptional() {
+        // Literal cannot contain optional, optional must contain a single group type object cases are covered at compile-time
+        regex {
+            optional {
+                literal { "a" }
+            }
+            matches { "a" }
+            no_match { "b" }
+            no_match { "aa" }
+        }
+    }
+    
+    @Test
+    fun testFailTestMatches() {
+        assertFailsWith<AssertionError> {
+            regex {
+                optional {
+                    literal { "a" }
+                }
+                matches { "abc" }
+            }
+        }
+    }
+    
+    @Test
+    fun testFailTestNoMatche() {
+        assertFailsWith<AssertionError> {
+            regex {
+                optional {
+                    literal { "a" }
+                }
+                no_match { "a" }
+            }
+        }
+    }
+    
+    @Test
+    fun testZeroOrMore() {
+        regex {
+            repeat(rule = RepetitionType.AT_LEAST, amount = 0) {
+                literal { "a" }
+            }
+            literal { "b" }
+            
+            matches { "ab" }
+            matches { "aaaab" }
+            matches { "b" }
+            no_match { "c" }
+        }
+    }
+    
+    @Test
+    fun testOneOrMore() {
+        regex {
+            repeat(rule = RepetitionType.AT_LEAST, amount = 1) {
+                literal { "a" }
+            }
+            
+            matches { "a" }
+            matches { "aaaaaa" }
+            no_match { "" }
+            no_match { "bc" }
+        }
+    }
+    
+    @Test
+    fun testWildCard() {
+        regex {
+            metacharacter { MetacharacterType.WILDCARD }
+            repeat(rule = RepetitionType.AT_LEAST, amount = 1) {
+                literal { "a" }
+            }
+            repeat(rule = RepetitionType.AT_LEAST, amount = 0) {
+                literal { "b" }
+            }
+            metacharacter { MetacharacterType.WILDCARD }
+            
+            matches { "zabx" }
+            matches { "zaaaaabx" }
+            matches { "zax" }
+            matches { "zabbbbbx" }
+            no_match { "ab" }
+            no_match { "ab" }
+        }
+    }
+    
+    @Test
+    fun testanyOf() {
+        regex {
+            range { '1'..'7' }
+            
+            matches { "1" }
+            matches { "4" }
+            matches { "7" }
+            no_match { "8" }
+            no_match { "0" }
+        }
+        
+        
+        println(regex {
+            either {
+                literal { "a" }
+                literal { "b" }
+                literal { "c" }
+            }
+        })
+        regex {
+            either {
+                literal { "a" }
+                literal { "b" }
+                literal { "c" }
+            }
+            
+            matches { "a" }
+            matches { "b" }
+            matches { "c" }
+            no_match { "ab" }
+            no_match { "bc" }
+            no_match { "d" }
+        }
+        
+        regex {
+            either {
+                literal { "a" }
+                literal { "b" }
+                range { 'D'..'F' }
+            }
+            
+            matches { "a" }
+            matches { "b" }
+            matches { "D" }
+            matches { "E" }
+            matches { "F" }
+            no_match { "c" }
+            no_match { "C" }
+            no_match { "aD" }
+        }
+        
+        regex {
+            either {
+                literal { "aa" }
+                literal { "bb" }
+            }
+            
+            matches { "aa" }
+            matches { "bb" }
+            no_match { "aabb" }
+            no_match { "acac" }
+        }
+    }
+    
+    @Test
+    fun testNoneOf() {
+        // TODO allow this behavior
+//        assertEquals("[^a-z]", regex {
+//            range(negated = true) { 'a'..'z' }
+//        }.toString())
+//
+//        assertEquals("[^abc]", regex {
+//            noneOf {
+//                "abc"
+//            }
+//        }.toString())
+//
+//        assertEquals("[^D-Fabc]", regex {
+//            noneOf {
+//                range { 'D'..'F' }
+//                literal { "a" }
+//                literal { "b" }
+//                literal { "c" }
+//            }
+//        }.toString())
+    }
+    
+    @Test
+    fun testWhitespace() {
+        regex {
+            metacharacter { MetacharacterType.WHITESPACE }
+            
+            matches { " " }
+            matches { "\n" }
+            no_match { "'" }
+        }
+    }
+    
+    @Test
+    fun testMetas() {
+        regex {
+            metacharacter { MetacharacterType.DIGIT }
+            either {
+                metacharacter { MetacharacterType.WHITESPACE }
+                metacharacter { MetacharacterType.WORD }
+            }
+            
+            matches { "8 " }
+            matches { "1c" }
+            matches { "1'" }
+            matches { "14" }
+            no_match { "ad" }
+            no_match { "9ad" }
+            
+        }
+    }
+    
+    
+    @Test
+    fun testNegatedRange() {
+        regex {
+            range(negated = true) { 'a'..'z' }
+            
+            matches { "12846" }
+            matches { "!$%$^&%*" }
+            no_match { "aksj" }
+        }
+    }
+    
+    @Test
+    fun testWhatever() {
+        regex {
+            repeat {
+                range { '0'..'9' }
+            }
+            either {
+                literal { " " }
+                literal { "\t" }
+            }
+            
+            matches { "1232424\t" }
+            matches { "1232424 " }
+            no_match { "a1278" }
+        }
+    }
+    
+    @Test
+    fun testLazy() {
+        val exp = regex {
+            literal { "'" }
+            repeat(behavior = QuantifierBehaviorType.LAZY, rule = RepetitionType.AT_LEAST, amount = 1) {
+                metacharacter { MetacharacterType.WORD }
+            }
+            literal { "'" }
+        }
+        assertEquals("'one'", exp.find("'one'blah blah'")?.value)
+    }
+    
+    @Test
+    fun testAnchors() {
+        regex {
+            anchor { AnchorType.START }
+            literal { "test" }
+            anchor { AnchorType.END }
+            
+            matches { "test" }
+            no_match { "atestb" }
+        }
+    }
+    
+    @Test
+    fun testRepeat() {
+        regex {
+            repeat(4, 4) {
+                literal { "r" }
+            }
+            
+            matches { "rrrr" }
+            no_match { "rrr" }
+            no_match { "rrrrr" }
+        }
+    }
+}

--- a/src/test/RegexTest.kt
+++ b/src/test/RegexTest.kt
@@ -202,7 +202,7 @@ internal class RegexTest {
             
             matches { "8 " }
             matches { "1c" }
-            matches { "1'" }
+            matches { "1_" }
             matches { "14" }
             no_match { "ad" }
             no_match { "9ad" }
@@ -213,12 +213,14 @@ internal class RegexTest {
     
     @Test
     fun testNegatedRange() {
+        print(regex {
+            range(negated = true) { 'a'..'z' }}.toString())
         regex {
             range(negated = true) { 'a'..'z' }
             
-            matches { "12846" }
-            matches { "!$%$^&%*" }
-            no_match { "aksj" }
+            matches { "1" }
+            matches { "!" }
+            no_match { "a" }
         }
     }
     


### PR DESCRIPTION
- Implement built in test framework
- Restore test suite, using built in test framework to avoid being tied to exact string output syntax
- Implement metacharacter toString
- Restore noneOf functionality, renamed to neither to match 'either'
